### PR TITLE
Trigger cljs file reload if readable

### DIFF
--- a/josh.cljs
+++ b/josh.cljs
@@ -219,8 +219,9 @@
                                 (.endsWith f ".cljs")
                                 (try
                                   (fs-sync/accessSync
-                                    f fs-sync/constants.X_OK)
-                                  (catch :default _e true)))))
+                                    f fs-sync/constants.R_OK)
+                                  true
+                                  (catch :default _e)))))
                         :recursive true}
                    #(frontend-file-changed %1 %2))
             ; launch the webserver

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node-watch": "^0.7.4"
   },
   "scripts": {
-    "prepare": "jq --argjson files \"$(git ls-files | jq -R . | jq -s .)\" '.files = $files' package.json > .package-tmp.json && mv .package-tmp.json package.json"
+    "prepare": "node -e \"if (process.platform !== 'win32') { require('child_process').execSync('npm run prepare:posix', { stdio: 'inherit' }); } else { console.log('Skipping prepare on Windows'); }\"",
+    "prepare:posix": "jq --argjson files \"$(git ls-files | jq -R . | jq -s .)\" '.files = $files' package.json > .package-tmp.json && mv .package-tmp.json package.json"
   },
   "files": [
     ".gitignore",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "node-watch": "^0.7.4"
   },
   "scripts": {
-    "prepare": "node -e \"if (process.platform !== 'win32') { require('child_process').execSync('npm run prepare:posix', { stdio: 'inherit' }); } else { console.log('Skipping prepare on Windows'); }\"",
-    "prepare:posix": "jq --argjson files \"$(git ls-files | jq -R . | jq -s .)\" '.files = $files' package.json > .package-tmp.json && mv .package-tmp.json package.json"
+    "prepublishOnly": "jq --argjson files \"$(git ls-files | jq -R . | jq -s .)\" '.files = $files' package.json > .package-tmp.json && mv .package-tmp.json package.json"
   },
   "files": [
     ".gitignore",


### PR DESCRIPTION
Hi,

can you please consider patch to consider cljs file for reloading if they are readable. It fixes #2.

The previous implementation checked if the file was executable (X_OK), which caused:

1. Linux: An exception was always thrown, defaulting to returning true triggering file reload.
2. Windows: nil was returned, preventing file reloads.

It seems to me the intention was to check for readability instead? This patch updates the logic accordingly.

API: https://nodejs.org/api/fs.html#fsaccesssyncpath-mode
Constants: https://nodejs.org/api/fs.html#file-access-constants

old code:
```cljs
(try
  (fs-sync/accessSync
    f fs-sync/constants.X_OK)
  (catch :default _e true))
```

Since no test suite is available, I have manually tested this change

command:
```powershell
> npx josh
Serving ./ on port 8000:
- http://192.168.1.100:8000
- http://127.0.0.1:8000
SSE connection established
SSE connection closed
SSE connection established
Frontend reloading: .#main.cljs
Frontend reloading: main.cljs
```

console:
```
Josh Scittle re-loader installed [scittle.min.js:323:125](https://cdn.jsdelivr.net/npm/scittle@latest/dist/scittle.min.js)
Reloading http://localhost:8000/main.cljs
```

I've also took the liberty to make the `scripts` > `prepare` unix specific command conditional skipping it on windows.

Thanks