### PR TITLE
frontend path updates should be relative to the serve dir

### DIFF
--- a/josh.cljs
+++ b/josh.cljs
@@ -222,7 +222,9 @@
                                     f fs-sync/constants.X_OK)
                                   (catch :default _e true)))))
                         :recursive true}
-                   #(frontend-file-changed %1 %2))
+                   (fn [event-type filepath]
+                     (let [filepath-rel (path/relative dir filepath)]
+                       (frontend-file-changed event-type filepath-rel))))
             ; launch the webserver
             (let [app (express)] 
               (.get app "/*" #(html-injector %1 %2 %3 dir))


### PR DESCRIPTION
Hi,

can you please consider patch to support hot reloading of files when the `-d dir` option is given. It fixes #4.

The problem was that file paths sent to the frontend for reloading need to be relative to the serving directory, but the file watcher reports them relative to the josh working directory. Thus the patch updates the file watcher paths to be relative to the serving dir. 

Thanks