### PR TITLE
added node import prefix

### DIFF
--- a/josh.mjs
+++ b/josh.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { addClassPath, loadFile } from 'nbb';
-import { fileURLToPath } from 'url';
-import { dirname, basename, resolve } from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname, basename, resolve } from 'node:path';
 
 const __dirname = fileURLToPath(dirname(import.meta.url));
 const __filename = basename(import.meta.url);


### PR DESCRIPTION
this enables cljs-josh to be run via `deno -A josh.mjs`. Not sure if it will work when it has been packaged.